### PR TITLE
Switch to boot.iso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+default:
+	packer build centos8.json
+debug:
+	rm -rf output-virtualbox-iso/ && \
+	packer build -on-error=abort centos8.json
+release:
+	packer build -var 'version=1.2.0' centos8.json

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,6 @@ Vagrant.configure("2") do |config|
       v.customize ["modifyvm", :id, "--ioapic", "on"]
     end
 
-    config.vm.provision "shell", inline: "echo Hello, World"
+    config.vm.provision "shell", inline: "cat /etc/centos-release;uname -a"
   end
-
 end

--- a/centos8.json
+++ b/centos8.json
@@ -31,11 +31,10 @@
       "headless": true,
       "http_directory": "http",
       "iso_urls": [
-        "TODO.iso",
-        "http://mirrors.mit.edu/centos/8/isos/x86_64/TODO.iso"
-      ],
+        "CentOS-8-x86_64-1905-boot.iso",
+        "https://mirror.ams1.nl.leaseweb.net/centos/8/isos/x86_64/CentOS-8-x86_64-1905-boot.iso"],
       "iso_checksum_type": "sha256",
-      "iso_checksum": "TODO",
+      "iso_checksum": "a7993a0d4b7fef2433e0d4f53530b63c715d3aadbe91f152ee5c3621139a2cbc",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,11 +64,6 @@
       {
         "output": "builds/{{.Provider}}-centos8.box",
         "type": "vagrant"
-      },
-      {
-        "type": "vagrant-cloud",
-        "box_tag": "geerlingguy/centos8",
-        "version": "{{user `version`}}"
       }
     ]
   ]

--- a/http/ks.cfg
+++ b/http/ks.cfg
@@ -1,69 +1,53 @@
+####### Centos 8 - @Core kickstart file
 install
-
+text
+eula --agreed
 
 lang en_US.UTF-8
 keyboard us
+timezone Europe/Amsterdam
 
 url --url https://mirror.ams1.nl.leaseweb.net/centos/8.0.1905/BaseOS/x86_64/os/
 
 network --bootproto=dhcp
-rootpw vagrant
 firewall --disabled
 selinux --permissive
-timezone UTC
+firstboot --disabled
 bootloader --location=mbr
-text
 skipx
 zerombr
 clearpart --all --initlabel
 autopart
 auth --enableshadow --passalgo=sha512 --kickstart
-firstboot --disabled
-eula --agreed
+rootpw vagrant
 services --enabled=NetworkManager,sshd
 reboot
-user --name=vagrant --plaintext --password vagrant --groups=vagrant,wheel
 
 %packages --ignoremissing --excludedocs
-@Base
 @Core
-@Development Tools
+curl
+haveged
+kernel-devel
+kernel-headers
+net-tools
 openssh-clients
-sudo
 openssl-devel
 readline-devel
-zlib-devel
-kernel-headers
-kernel-devel
-net-tools
-vim
-wget
-curl
 rsync
-
-# unnecessary firmware
+sudo
+vim-enhanced
+wget
+zlib-devel
+# and remove (wireless) firmware(s)
 -aic94xx-firmware
 -atmel-firmware
 -b43-openfwwf
 -bfa-firmware
--ipw2100-firmware
--ipw2200-firmware
+-ipw*-firmware
 -ivtv-firmware
--iwl100-firmware
--iwl1000-firmware
--iwl3945-firmware
--iwl4965-firmware
--iwl5000-firmware
--iwl5150-firmware
--iwl6000-firmware
--iwl6000g2a-firmware
--iwl6050-firmware
+-iwl*-firmware
 -libertas-usb8388-firmware
--ql2100-firmware
--ql2200-firmware
--ql23xx-firmware
--ql2400-firmware
--ql2500-firmware
+-ql*-firmware
 -rt61pci-firmware
 -rt73usb-firmware
 -xorg-x11-drv-ati-firmware
@@ -71,15 +55,13 @@ rsync
 %end
 
 %post
-yum update -y
-
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
-
-# sudo
-yum install -y sudo
+useradd vagrant && usermod -a -G wheel vagrant
+echo "vagrant"|passwd vagrant --stdin
 echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+dnf -y remove iwl*-firmware
+dnf update -y
 
-yum clean all
+package-cleanup -q --leaves | xargs -l1 dnf -y remove
+dnf -y clean all
 %end

--- a/http/ks.cfg
+++ b/http/ks.cfg
@@ -1,7 +1,11 @@
 install
-cdrom
+
+
 lang en_US.UTF-8
 keyboard us
+
+url --url https://mirror.ams1.nl.leaseweb.net/centos/8.0.1905/BaseOS/x86_64/os/
+
 network --bootproto=dhcp
 rootpw vagrant
 firewall --disabled

--- a/http/ks.cfg
+++ b/http/ks.cfg
@@ -2,13 +2,11 @@ install
 cdrom
 lang en_US.UTF-8
 keyboard us
-unsupported_hardware
 network --bootproto=dhcp
 rootpw vagrant
 firewall --disabled
 selinux --permissive
 timezone UTC
-unsupported_hardware
 bootloader --location=mbr
 text
 skipx

--- a/http/ks.cfg
+++ b/http/ks.cfg
@@ -62,6 +62,6 @@ sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 dnf -y remove iwl*-firmware
 dnf update -y
 
-package-cleanup -q --leaves | xargs -l1 dnf -y remove
+dnf list autoremove|xargs -l1 dnf -y remove
 dnf -y clean all
 %end

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,3 @@
 ---
-- src: geerlingguy.packer-rhel
+- src: geerlingguy.packer_rhel
 - src: geerlingguy.nfs

--- a/scripts/ansible.sh
+++ b/scripts/ansible.sh
@@ -1,4 +1,8 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash -eux
+
+# Install Python.
+dnf -y install python3 python3-pip
+alternatives --set python /usr/bin/python3
 
 # Install Ansible.
-yum -y install ansible
+pip3 install ansible

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,9 +1,14 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash -eux
 
 # Remove Ansible and its dependencies.
-yum -y remove ansible
+pip3 install pip-autoremove
+ln -s /usr/bin/pip3 /usr/bin/pip
+pip-autoremove ansible -y
+rm -f /usr/bin/pip
+pip3 uninstall pip-autoremove -y
 
 # Zero out the rest of the free space using dd, then delete the written file.
+echo "Writing zeroes to free space (this could take a while)."
 dd if=/dev/zero of=/EMPTY bs=1M
 rm -f /EMPTY
 


### PR DESCRIPTION
@geerlingguy as dicussed in https://github.com/geerlingguy/packer-centos-8/issues/3 , this PR is a working example which will perform a @core installation with the CentOS-8-x86_64-1905-boot iso. This install downloads 416 packages instead of 700ish which saves a lot of bandwith.

- refactored the ks.cfg
- used globbing for the package removal
- substituted yum commands for dnf 
- added a Makefile.
